### PR TITLE
Add maxLength support to AutoFill method in TextInput

### DIFF
--- a/input.go
+++ b/input.go
@@ -119,6 +119,10 @@ func (i TextInput) AutoFill() (value []string) {
 		length = i.minLength
 		return []string{randomString(length)}
 	}
+	if i.maxLength > 0 {
+		length = i.maxLength
+		return []string{randomString(length)}
+	}
 	return i.anyInput.AutoFill()
 }
 


### PR DESCRIPTION
This pull request fixes an issue with the `TextInput.AutoFill` function.

When `maxLength` is set to less than 9, the value returned by `TextInput.AutoFill` (see [input.go#L54-L56](https://github.com/jeremija/gosubmit/blob/df6d06a8e7acbcf2e00c0afb299b1b72fd5ab545/input.go#L54-L56)) exceeds 9 characters (the length of `-autofill`), causing it to fail the check at:

https://github.com/jeremija/gosubmit/blob/df6d06a8e7acbcf2e00c0afb299b1b72fd5ab545/input.go#L104

This failure occurs during the execution of:

https://github.com/jeremija/gosubmit/blob/df6d06a8e7acbcf2e00c0afb299b1b72fd5ab545/fill.go#L316-L319